### PR TITLE
Changing MEDIA references to STATIC in template

### DIFF
--- a/html5boilerplate/templates/html5boilerplate/base.html
+++ b/html5boilerplate/templates/html5boilerplate/base.html
@@ -17,8 +17,8 @@
         {% endblock %}
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <link rel="shortcut icon" href="{{ MEDIA_URL }}img/favicon.ico">
-        <link rel="apple-touch-icon" href="{{ MEDIA_URL }}img/apple-touch-icon.png">
+        <link rel="shortcut icon" href="{{ html5boilerplate_static_prefix_setting }}img/favicon.ico">
+        <link rel="apple-touch-icon" href="{{ html5boilerplate_static_prefix_setting }}img/apple-touch-icon.png">
 
         {% block stylesheets %}
             <link rel="stylesheet" href="{% html5boilerplate_static_prefix_setting %}css/style.css?v=2">
@@ -58,8 +58,8 @@
             {% load_jquery %}
      
             {% block my_javascript %}
-                <script src="{{ MEDIA_URL }}js/plugins.js"></script>
-                <script src="{{ MEDIA_URL }}js/script.js"></script>
+                <script src="{% html5boilerplate_static_prefix_setting %}js/plugins.js"></script>
+                <script src="{% html5boilerplate_static_prefix_setting %}js/script.js"></script>
             {% endblock %}
 
             {% block png_fix %}

--- a/html5boilerplate/templatetags/html5boilerplate_tags.py
+++ b/html5boilerplate/templatetags/html5boilerplate_tags.py
@@ -6,10 +6,10 @@ import re
 
 register = template.Library()
 
-_HTML5_BOILERPLATE_MEDIA_PREFIX = getattr(settings, 'HTML5_BOILERPLATE_MEDIA_PREFIX', '/static/html5boilerplate/')
+_HTML5_BOILERPLATE_STATIC_PREFIX = getattr(settings, 'HTML5_BOILERPLATE_STATIC_PREFIX', '/static/html5boilerplate/')
 _DEFAULT_JQUERY_SOURCES = (
     '//ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.js',
-    _HTML5_BOILERPLATE_MEDIA_PREFIX + 'js/libs/jquery-1.4.2.js',
+    _HTML5_BOILERPLATE_STATIC_PREFIX + 'js/libs/jquery-1.4.2.js',
 )
 
 
@@ -123,4 +123,4 @@ def html5boilerplate_static_prefix_setting():
     """
     For internal use only.
     """
-    return _HTML5_BOILERPLATE_MEDIA_PREFIX
+    return _HTML5_BOILERPLATE_STATIC_PREFIX


### PR DESCRIPTION
Might need to give some of this a bit more thought (such as how to allow a user to override project-specific static files like favicon, script.js, etc)
